### PR TITLE
Changed insults to a group command and added aliases

### DIFF
--- a/bot/features/insult/insult.py
+++ b/bot/features/insult/insult.py
@@ -58,9 +58,10 @@ class Insult(TGACog):
         if ctx.message.author == self.bot.user:
             return
         else:
-            for mention in ctx.message.mentions:
-                await ctx.message.channel.send(
-                    f"{mention.mention} {self.getInsult()}")
+            if ctx.invoked_subcommand is None:
+                for mention in ctx.message.mentions:
+                    await ctx.message.channel.send(
+                        f"{mention.mention} {self.getInsult()}")
 
     @insult.command(aliases=['t'])
     async def torment(self, ctx):


### PR DESCRIPTION
torment and untorment now live under the insult command
insult torment
insult untorment

They are also aliases as
insult | i
torment | t
untorment | u

e.g. !i t @user would torment @user

Also added an error handler but not sure how it is used yet.